### PR TITLE
feat(berry): add support for berry

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
     "nock": "^10.0.0",
-    "probot": "^10.0.0"
+    "probot": "^10.0.0",
+    "yaml": "^1.10.2"
   },
   "devDependencies": {
     "@types/jest": "^23.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6511,6 +6511,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
 yargs-parser@10.x:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"


### PR DESCRIPTION
Add support for berry (yarn 2+) which uses pure yaml for its lockfile

Fixes #10